### PR TITLE
Changed version on Webpack package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "mocha": "^3.2.0",
     "react-scripts": "^1.0.7",
     "react-test-renderer": "^15.5.4",
-    "webpack": "^1.14.0",
+    "webpack": "^2.2.0",
     "webpack-dev-server": "^1.16.2"
   },
   "dependencies": {


### PR DESCRIPTION
Even with the Caret, the webpack version only installs version `1.15.0` despite the current version being `2.6.1`. This causes a dependency error that makes `npm start` unable to compile the lab code as another package requires version `2.2.0`